### PR TITLE
Add upgrade functionality to Starknet store contract

### DIFF
--- a/contracts/starknet/Scarb.lock
+++ b/contracts/starknet/Scarb.lock
@@ -6,6 +6,7 @@ name = "fossil_store"
 version = "0.1.0"
 dependencies = [
  "openzeppelin_access",
+ "openzeppelin_upgrades",
  "snforge_std",
  "verifier",
 ]

--- a/contracts/starknet/store/Scarb.toml
+++ b/contracts/starknet/store/Scarb.toml
@@ -9,7 +9,7 @@ edition = "2023_11"
 starknet.workspace = true
 verifier = { path = "../verifier" }
 openzeppelin_access.workspace = true
-
+openzeppelin_upgrades.workspace = true
 [dev-dependencies]
 assert_macros.workspace = true
 snforge_std.workspace = true


### PR DESCRIPTION
This commit:
1. Adds the openzeppelin_upgrades dependency to the store contract
2. Implements the upgrade method in the IFossilStore trait
3. Adds the UpgradeableComponent to the Store contract
4. Adds proper storage and event handling for upgrades
5. Implements the upgrade method with owner-only access control

The upgrade functionality allows the contract owner to upgrade the implementation while preserving the contract's state, enabling future improvements without data migration.