### PR TITLE
fix: deploy starknet env type failing checks

### DIFF
--- a/scripts/deploy-starknet.sh
+++ b/scripts/deploy-starknet.sh
@@ -6,20 +6,6 @@ set -e
 # Store the original directory (works both in container and local environment)
 ORIGINAL_DIR="$(pwd)"
 
-# Set update interval based on environment
-case "$ENV_TYPE" in
-    "local" | "docker")
-        UPDATE_INTERVAL=0
-        ;;
-    "sepolia" | "mainnet")
-        UPDATE_INTERVAL=900
-        ;;
-    *)
-        echo "Invalid environment. Must be one of: local, sepolia, mainnet, docker"
-        exit 1
-        ;;
-esac
-
 # Default build flag (true means we will build)
 BUILD=true
 
@@ -81,6 +67,20 @@ case "$ENV_TYPE" in
         echo "Invalid environment. Must be one of: local, sepolia, mainnet, docker"
         exit 1
     ;;
+esac
+
+# Set update interval based on environment
+case "$ENV_TYPE" in
+    "local" | "docker")
+        UPDATE_INTERVAL=0
+        ;;
+    "sepolia" | "mainnet")
+        UPDATE_INTERVAL=900
+        ;;
+    *)
+        echo "Invalid environment. Must be one of: local, sepolia, mainnet, docker"
+        exit 1
+        ;;
 esac
 
 # Check if environment files exist


### PR DESCRIPTION
The `deploy-starknet.sh` script is failing even when correct args were provided due to checks for the `ENV_TYPE` args happening before the arguments were parsed in an attempt to set the `UPDATE_INTERVAL`.

This PR attempts to fix it by moving the conditionals down.